### PR TITLE
Fixed some compilation error in SDK-conditional code. Also silenced compiler warnings on deprecated minimumFontSize.

### DIFF
--- a/THLabel/THLabel.m
+++ b/THLabel/THLabel.m
@@ -360,10 +360,15 @@ typedef enum {
 	if ([self respondsToSelector:@selector(minimumScaleFactor)]) {
 		minFontSize = self.minimumScaleFactor ? self.minimumScaleFactor * *actualFontSize : *actualFontSize;
 	}
-#endif
 	else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 		minFontSize = self.minimumFontSize ? : *actualFontSize;
+#pragma clang diagnostic pop
 	}
+#else
+  minFontSize = self.minimumFontSize ? : *actualFontSize;
+#endif
 	
 	// Calculate text rect size.
 	if (self.adjustsFontSizeToFitWidth && self.numberOfLines == 1) {


### PR DESCRIPTION
Fixes build issue with dangling "else" when max allowed SDK version is
less than 6.0. Also suppresses deprecation warnings for minimumFontSize
in case when respondsToSelector returns false.
