### PR TITLE
Update THLabel.podspec with missing dependencies

### DIFF
--- a/THLabel.podspec
+++ b/THLabel.podspec
@@ -9,5 +9,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/MuscleRumble/THLabel.git', :tag => s.version.to_s }
   s.platform     = :ios, '4.0'
   s.source_files = 'THLabel'
+  s.framework    = 'CoreText'
   s.requires_arc = true
 end


### PR DESCRIPTION
As `THLabel` build on top of `CoreText` we need to add it into specification file.
