### PR TITLE
[Add] Use the letterSpacing attribute to change font kerning

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ You can fade in/out your label by setting the `fadeTruncatingMode` property. Def
 
 Effects like stroke and shadow can't be drawn outside of the bounds of the label view. For labels that are not center-aligned, you may need to set text insets to move a bit away from the edge.
 
+``` objective-c
+	@property (nonatomic, assign) CGFloat letterSpacing;
+```
+
+You can programmatically modify the letter spacing of the text (eg. the kern amount between characters) by changing the `letterSpacing` property. The default value is `0`; a positive value will separate characters, whereas a negative value will make them closer.
+
 ## Notes
 
 THLabel respects (unlike UILabel) the `contentMode` property, which is used for vertical alignment. The `textAlignment` still has the higher priority, when it comes to horizontal alignment.

--- a/THLabel/THLabel.h
+++ b/THLabel/THLabel.h
@@ -69,6 +69,8 @@ typedef NS_OPTIONS(NSUInteger, THLabelFadeTruncatingMode) {
 @property (nonatomic, strong) UIColor *strokeColor;
 @property (nonatomic, assign) THLabelStrokePosition strokePosition;
 
+@property (nonatomic, assign) CGFloat letterSpacing;
+
 @property (nonatomic, strong) UIColor *gradientStartColor;
 @property (nonatomic, strong) UIColor *gradientEndColor;
 @property (nonatomic, copy) NSArray *gradientColors;

--- a/THLabel/THLabel.m
+++ b/THLabel/THLabel.m
@@ -73,6 +73,7 @@
 - (void)setDefaults {
 	self.gradientStartPoint = CGPointMake(0.5, 0.2);
 	self.gradientEndPoint = CGPointMake(0.5, 0.8);
+	self.letterSpacing = 0.0f;
 }
 
 #pragma mark - Accessors and Mutators
@@ -391,9 +392,13 @@
 	};
 	CTParagraphStyleRef paragraphStyleRef = CTParagraphStyleCreate(paragraphStyleSettings, 2);
 	
+	// Set up kerning
+	CFNumberRef kernRef = CFNumberCreate(NULL, kCFNumberDoubleType, &_letterSpacing);
+  
 	// Set up attributed string.
-	CFStringRef keys[] = {kCTFontAttributeName, kCTParagraphStyleAttributeName, kCTForegroundColorAttributeName};
-	CFTypeRef values[] = {fontRef, paragraphStyleRef, self.textColor.CGColor};
+  
+	CFStringRef keys[] = {kCTFontAttributeName, kCTParagraphStyleAttributeName, kCTForegroundColorAttributeName, kCTKernAttributeName};
+	CFTypeRef values[] = {fontRef, paragraphStyleRef, self.textColor.CGColor, kernRef};
 	CFDictionaryRef attributes = CFDictionaryCreate(kCFAllocatorDefault, (const void **)&keys, (const void **)&values, sizeof(keys) / sizeof(keys[0]), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 	CFRelease(fontRef);
 	CFRelease(paragraphStyleRef);


### PR DESCRIPTION
I've add a `letterSpacing` attribute to be able to change the kerning of the label font.
This is particularly useful when adding a stroke to the label, since the stroke will reduce the visible space between characters.
